### PR TITLE
fix(cli): Dump config in gitconfig format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,7 +339,6 @@ dependencies = [
  "serde",
  "serde_json",
  "structopt",
- "toml",
  "treeline",
  "vec1",
  "yansi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,6 @@ atty = "0.2"
 itertools = "0.10"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-toml = "0.5"
 ignore = "0.4"
 bstr = "0.2"
 maplit = "1"

--- a/src/bin/git-stack/config.rs
+++ b/src/bin/git-stack/config.rs
@@ -14,7 +14,7 @@ pub fn dump_config(
         .with_code(proc_exit::Code::CONFIG_ERR)?
         .update(args.to_config());
 
-    let output = toml::to_string_pretty(&repo_config).with_code(proc_exit::Code::FAILURE)?;
+    let output = repo_config.to_string();
 
     if output_path == std::path::Path::new("-") {
         std::io::stdout().write_all(output.as_bytes())?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,13 +14,14 @@ pub struct RepoConfig {
 }
 
 static PROTECTED_STACK_FIELD: &str = "stack.protected-branch";
-static DEFAULT_PROTECTED_BRANCHES: [&str; 4] = ["main", "master", "dev", "stable"];
 static STACK_FIELD: &str = "stack.stack";
 static PUSH_REMOTE_FIELD: &str = "stack.push-remote";
 static PULL_REMOTE_FIELD: &str = "stack.pull-remote";
 static FORMAT_FIELD: &str = "stack.show-format";
 static STACKED_FIELD: &str = "stack.show-stacked";
 static BACKUP_CAPACITY_FIELD: &str = "branch-backup.capacity";
+
+static DEFAULT_PROTECTED_BRANCHES: [&str; 4] = ["main", "master", "dev", "stable"];
 const DEFAULT_CAPACITY: usize = 30;
 
 impl RepoConfig {
@@ -290,6 +291,58 @@ impl RepoConfig {
     pub fn capacity(&self) -> Option<usize> {
         let capacity = self.capacity.unwrap_or(DEFAULT_CAPACITY);
         (capacity != 0).then(|| capacity)
+    }
+}
+
+impl std::fmt::Display for RepoConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "[{}]", STACK_FIELD.split_once(".").unwrap().0)?;
+        for branch in self.protected_branches() {
+            writeln!(
+                f,
+                "\t{}={}",
+                PROTECTED_STACK_FIELD.split_once(".").unwrap().1,
+                branch
+            )?;
+        }
+        writeln!(
+            f,
+            "\t{}={}",
+            STACK_FIELD.split_once(".").unwrap().1,
+            self.stack()
+        )?;
+        writeln!(
+            f,
+            "\t{}={}",
+            PUSH_REMOTE_FIELD.split_once(".").unwrap().1,
+            self.push_remote()
+        )?;
+        writeln!(
+            f,
+            "\t{}={}",
+            PULL_REMOTE_FIELD.split_once(".").unwrap().1,
+            self.pull_remote()
+        )?;
+        writeln!(
+            f,
+            "\t{}={}",
+            FORMAT_FIELD.split_once(".").unwrap().1,
+            self.show_format()
+        )?;
+        writeln!(
+            f,
+            "\t{}={}",
+            STACKED_FIELD.split_once(".").unwrap().1,
+            self.show_stacked()
+        )?;
+        writeln!(f, "[{}]", BACKUP_CAPACITY_FIELD.split_once(".").unwrap().0)?;
+        writeln!(
+            f,
+            "\t{}={}",
+            BACKUP_CAPACITY_FIELD.split_once(".").unwrap().1,
+            self.capacity().unwrap_or(0)
+        )?;
+        Ok(())
     }
 }
 


### PR DESCRIPTION
Unfortunately, I couldn't find a way with libgit2 to do this.  There
doesn't seem to be a way to copy values between configs to write to a
temp file.  There doesn't seem to be any in-memory writing/reading
support.

So had to do it by hand and hope its good enough.

Fixes #10