### PR TITLE
fix(config): Actually read strings from config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -204,21 +204,21 @@ impl RepoConfig {
         let pull_remote = config.get_string(PULL_REMOTE_FIELD).ok();
 
         let stack = config
-            .get_str(STACK_FIELD)
+            .get_string(STACK_FIELD)
             .ok()
-            .and_then(|s| FromStr::from_str(s).ok());
+            .and_then(|s| FromStr::from_str(&s).ok());
 
         let show_format = config
-            .get_str(FORMAT_FIELD)
+            .get_string(FORMAT_FIELD)
             .ok()
-            .and_then(|s| FromStr::from_str(s).ok());
+            .and_then(|s| FromStr::from_str(&s).ok());
 
         let show_stacked = config.get_bool(STACKED_FIELD).ok();
 
         let auto_fixup = config
-            .get_str(AUTO_FIXUP_FIELD)
+            .get_string(AUTO_FIXUP_FIELD)
             .ok()
-            .and_then(|s| FromStr::from_str(s).ok());
+            .and_then(|s| FromStr::from_str(&s).ok());
 
         let capacity = config
             .get_i64(BACKUP_CAPACITY_FIELD)


### PR DESCRIPTION
It turns out `git2::Config::get_str` always fails.  See
https://github.com/rust-lang/git2-rs/issues/474

To workaround this, we are switching to `get_string`.

Fixes #96