### PR TITLE
fix(cli): Consolidate empty stacks

### DIFF
--- a/src/bin/git-stack/main.rs
+++ b/src/bin/git-stack/main.rs
@@ -42,7 +42,7 @@ fn run() -> proc_exit::ExitResult {
     } else if args.protected {
         config::protected(&args)?;
     } else {
-        stack::stack(&args, colored_stdout)?;
+        stack::stack(&args, colored_stdout, colored_stderr)?;
     }
 
     Ok(())

--- a/src/git/branches.rs
+++ b/src/git/branches.rs
@@ -66,6 +66,10 @@ impl Branches {
         self.branches.is_empty()
     }
 
+    pub fn len(&self) -> usize {
+        self.branches.len()
+    }
+
     pub fn all(&self) -> Self {
         self.clone()
     }


### PR DESCRIPTION
Building on #116, if there are N empty stacks, they should now
take up one line instead of N lines.

We'll still show it if its the HEAD.

Fixes #114