### PR TITLE
fix(cli): Reduce chance for stackoverflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-header -->
 ## [Unreleased] - ReleaseDate
 
+#### Fixes
+
+- Further reduce the chance for stackoverflows
+
 ## [0.4.5] - 2021-10-22
 
 #### Fixes


### PR DESCRIPTION
While I removed stackoverflows from our operations and reduced the
number of visible commits, I didn't remove the impact of visualizing a
lot of commits.

This change reduces the chance further by making most rendering paths
not stackoverflow.   A user still can with `--format commits`.  More
work will be needed to cover that case.

As a side effect. we are doing less work when rendering.

This is a part of #90