### PR TITLE
fix(git): Fixup should only squash one commit

### DIFF
--- a/tests/repo.rs
+++ b/tests/repo.rs
@@ -315,7 +315,7 @@ fn squash_clean() {
         assert!(!repo.is_dirty());
 
         let base = repo.find_local_branch("master").unwrap();
-        let source = repo.find_local_branch("feature2").unwrap();
+        let source = repo.find_local_branch("feature1").unwrap();
         let dest_id = repo.squash(source.id, base.id).unwrap();
 
         repo.branch("squashed", dest_id).unwrap();


### PR DESCRIPTION
With commits like
- `commita`
- `commitb`
- `fixup!: commita`
we were getting
- `commita`

It was unclear what selecting the base for `merge_trees` does, so we
were using the merge base of the fixup and its target.  On a whim, I
tried changing it to the parent of the fixup and it seemed to work!

Fixes #137