### PR TITLE
feat(graph): Align stacks on repair

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -128,3 +128,4 @@ Configuration is read from the following (in precedence order):
 | stack.show-format      | --format | "silent", "branches", "branch-commits", "commits", "debug"  | How to show the stacked diffs at the end |
 | stack.show-stacked     | \-       | bool                       | Show branches as stacked on top of each other, where possible |
 | stack.auto-fixup       | --fixup  | "ignore", "move", "squash" | Default fixup operation with `--rebase` |
+| stack.auto-repair      | \-       | bool                       | Perform branch repair with `--rebase` |

--- a/src/bin/git-stack/args.rs
+++ b/src/bin/git-stack/args.rs
@@ -44,6 +44,12 @@ pub struct Args {
     )]
     pub fixup: Option<git_stack::config::Fixup>,
 
+    /// Repair diverging branches.
+    #[structopt(long, overrides_with("no-repair"))]
+    repair: bool,
+    #[structopt(long, overrides_with("repair"), hidden(true))]
+    no_repair: bool,
+
     #[structopt(short = "n", long)]
     pub dry_run: bool,
 
@@ -85,8 +91,22 @@ impl Args {
             show_format: self.format,
             show_stacked: None,
             auto_fixup: None,
+            auto_repair: None,
 
             capacity: None,
         }
+    }
+
+    pub fn repair(&self) -> Option<bool> {
+        resolve_bool_arg(self.repair, self.no_repair)
+    }
+}
+
+fn resolve_bool_arg(yes: bool, no: bool) -> Option<bool> {
+    match (yes, no) {
+        (true, false) => Some(true),
+        (false, true) => Some(false),
+        (false, false) => None,
+        (_, _) => unreachable!("StructOpt should make this impossible"),
     }
 }


### PR DESCRIPTION
Auto-repair is starting off-by-default as we get runtime to see how well
we trust it.

Our backup approach in case aligning by time doesn't work is to prefer
HEAD.

Fixes #6