### PR TITLE
feat(cli): Support `-C`

### DIFF
--- a/src/bin/git-stack/args.rs
+++ b/src/bin/git-stack/args.rs
@@ -58,6 +58,20 @@ pub struct Args {
     #[clap(long, group = "mode")]
     pub protect: Option<String>,
 
+    /// Run as if git was started in `PATH` instead of the current working directory.
+    ///
+    /// When multiple -C options are given, each subsequent
+    /// non-absolute -C <path> is interpreted relative to the preceding -C <path>. If <path> is present but empty, e.g.  -C "", then the
+    /// current working directory is left unchanged.
+    ///
+    /// This option affects options that expect path name like --git-dir and --work-tree in that their interpretations of the path names
+    /// would be made relative to the working directory caused by the -C option. For example the following invocations are equivalent:
+    ///
+    ///     git --git-dir=a.git --work-tree=b -C c status
+    ///     git --git-dir=c/a.git --work-tree=c/b status
+    #[clap(short = 'C', hide = true, value_name = "PATH", parse(from_os_str))]
+    pub current_dir: Option<Vec<std::path::PathBuf>>,
+
     /// Write the current configuration to file with `-` for stdout
     #[clap(long, parse(from_os_str), group = "mode")]
     pub dump_config: Option<std::path::PathBuf>,


### PR DESCRIPTION
This helps when running outside of `git`.  Because of the limited case,
its hidden.

This supersedes #195