### PR TITLE
perf: Remove a lot of uses of fully-sorted commit graph

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,7 @@ dependencies = [
  "human-panic",
  "humantime",
  "ignore",
+ "indexmap",
  "itertools",
  "log",
  "maplit",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ proc-exit = "1"
 eyre = "0.6"
 human-panic = "1"
 termtree = "0.2.4"
+indexmap = "1"
 
 git2-ext = "0.0.5"
 git-branch-stash = "0.8"

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -456,11 +456,11 @@ fn plan_changes(state: &State, stack: &StackState) -> eyre::Result<git_stack::gi
         git_stack::graph::rebase_development_branches(&mut graph, onto_id);
         git_stack::graph::rebase_pulled_branches(&mut graph, pull_start_id, onto_id);
 
-        let pull_range: Vec<_> = state
-            .repo
-            .commits_from(onto_id)
-            .take_while(|c| c.id != pull_start_id)
-            .collect();
+        let pull_range: Vec<_> =
+            git_stack::git::commits_since(&state.repo, pull_start_id, onto_id)?
+                .into_iter()
+                .map(|id| state.repo.find_commit(id).unwrap())
+                .collect();
         git_stack::graph::drop_squashed_by_tree_id(
             &mut graph,
             pull_range.iter().map(|c| c.tree_id),
@@ -617,11 +617,11 @@ fn show(state: &State, colored_stdout: bool, colored_stderr: bool) -> eyre::Resu
                 git_stack::graph::rebase_development_branches(&mut graph, onto_id);
                 git_stack::graph::rebase_pulled_branches(&mut graph, pull_start_id, onto_id);
 
-                let pull_range: Vec<_> = state
-                    .repo
-                    .commits_from(onto_id)
-                    .take_while(|c| c.id != pull_start_id)
-                    .collect();
+                let pull_range: Vec<_> =
+                    git_stack::git::commits_since(&state.repo, pull_start_id, onto_id)?
+                        .into_iter()
+                        .map(|id| state.repo.find_commit(id).unwrap())
+                        .collect();
                 git_stack::graph::drop_squashed_by_tree_id(
                     &mut graph,
                     pull_range.iter().map(|c| c.tree_id),

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -1471,14 +1471,8 @@ fn commit_relation(
     }
 
     let base = repo.merge_base(local, remote)?;
-    let local_count = repo
-        .commits_from(local)
-        .take_while(|c| c.id != base)
-        .count();
-    let remote_count = repo
-        .commits_from(remote)
-        .take_while(|c| c.id != base)
-        .count();
+    let local_count = repo.commit_count(base, local)?;
+    let remote_count = repo.commit_count(base, remote)?;
     Some((local_count, remote_count))
 }
 

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -456,11 +456,10 @@ fn plan_changes(state: &State, stack: &StackState) -> eyre::Result<git_stack::gi
         git_stack::graph::rebase_development_branches(&mut graph, onto_id);
         git_stack::graph::rebase_pulled_branches(&mut graph, pull_start_id, onto_id);
 
-        let pull_range: Vec<_> =
-            git_stack::git::commits_since(&state.repo, pull_start_id, onto_id)?
-                .into_iter()
-                .map(|id| state.repo.find_commit(id).unwrap())
-                .collect();
+        let pull_range: Vec<_> = git_stack::git::commit_range(&state.repo, onto_id..pull_start_id)?
+            .into_iter()
+            .map(|id| state.repo.find_commit(id).unwrap())
+            .collect();
         git_stack::graph::drop_squashed_by_tree_id(
             &mut graph,
             pull_range.iter().map(|c| c.tree_id),
@@ -618,7 +617,7 @@ fn show(state: &State, colored_stdout: bool, colored_stderr: bool) -> eyre::Resu
                 git_stack::graph::rebase_pulled_branches(&mut graph, pull_start_id, onto_id);
 
                 let pull_range: Vec<_> =
-                    git_stack::git::commits_since(&state.repo, pull_start_id, onto_id)?
+                    git_stack::git::commit_range(&state.repo, onto_id..pull_start_id)?
                         .into_iter()
                         .map(|id| state.repo.find_commit(id).unwrap())
                         .collect();

--- a/src/git/branches.rs
+++ b/src/git/branches.rs
@@ -285,7 +285,8 @@ pub fn find_protected_base<'b>(
     while let Some(parent_oid) = repo
         .parent_ids(child_oid)
         .expect("child_oid came from verified source")
-        .next()
+        .first()
+        .copied()
     {
         if let Some((_, closest_common_oid)) = protected_base_oids
             .iter()

--- a/src/git/branches.rs
+++ b/src/git/branches.rs
@@ -273,20 +273,3 @@ pub fn find_protected_base<'b>(
         })
         .next()
 }
-
-pub fn find_base<'b>(
-    repo: &dyn crate::git::Repo,
-    branches: &'b Branches,
-    head_oid: git2::Oid,
-) -> Option<&'b crate::git::Branch> {
-    repo.commits_from(head_oid)
-        .filter(|c| c.id != head_oid)
-        .filter_map(|commit| {
-            branches.get(commit.id).map(|branches| {
-                branches
-                    .first()
-                    .expect("there should always be at least one")
-            })
-        })
-        .next()
-}

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -1051,8 +1051,9 @@ pub fn commit_range_inner(
             }
             continue;
         }
-        results.insert(next_id);
-        enqueue_parents(&mut queue, repo, base_id, next_id)?;
+        if results.insert(next_id) {
+            enqueue_parents(&mut queue, repo, base_id, next_id)?;
+        }
     }
 
     Ok(results)

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -22,7 +22,12 @@ pub fn protect_branches(
             .map(|merge_base_oid| merge_base_oid == root_id)
             .unwrap_or(false)
     }) {
-        for commit in repo.commits_from(protected_oid) {
+        for commit_id in
+            crate::git::commit_range(repo, protected_oid..=root_id).expect("IDs already validated")
+        {
+            let commit = repo
+                .find_commit(commit_id)
+                .expect("commit_range returns valid commits");
             if let Some(node) = graph.get_mut(commit.id) {
                 if node.action.is_protected() {
                     break;


### PR DESCRIPTION
This is a step towards #194.  Using an unbounded revwalk that is topologically sorted is very expensive, once.

This removes most uses and speeds things up when there are no feature branches.  With only `master` on `gecko-dev`, we went from ~25s to <1s.  However, we still need to remove the last topoligical sort which is used for creating the commit graph, so generally people will not see a speed up yet.

However, we did improve the logic for picking protected bases as part of this.