### PR TITLE
feat(git): Include matching pull branches

### DIFF
--- a/src/bin/git-stack/config.rs
+++ b/src/bin/git-stack/config.rs
@@ -65,6 +65,10 @@ pub fn protected(args: &crate::args::Args) -> proc_exit::ExitResult {
         if protected.is_protected(&branch.name) {
             log::trace!("Branch {} is protected", branch);
             protected_branches.insert(branch.clone());
+            if let Some(remote) = repo.find_remote_branch(repo.pull_remote(), &branch.name) {
+                protected_branches.insert(remote.clone());
+                branches.insert(remote);
+            }
         }
         branches.insert(branch);
     }

--- a/src/bin/git-stack/config.rs
+++ b/src/bin/git-stack/config.rs
@@ -59,8 +59,15 @@ pub fn protected(args: &crate::args::Args) -> proc_exit::ExitResult {
     .with_code(proc_exit::Code::CONFIG_ERR)?;
 
     let repo = git_stack::git::GitRepo::new(repo);
-    let branches = git_stack::git::Branches::new(repo.local_branches());
-    let protected_branches = branches.protected(&protected);
+    let mut branches = git_stack::git::Branches::new([]);
+    let mut protected_branches = git_stack::git::Branches::new([]);
+    for branch in repo.local_branches() {
+        if protected.is_protected(&branch.name) {
+            log::trace!("Branch {} is protected", branch);
+            protected_branches.insert(branch.clone());
+        }
+        branches.insert(branch);
+    }
 
     for (branch_id, branches) in branches.iter() {
         if protected_branches.contains_oid(branch_id) {

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -92,8 +92,15 @@ impl State {
         repo.set_push_remote(repo_config.push_remote());
         repo.set_pull_remote(repo_config.pull_remote());
 
-        let branches = git_stack::git::Branches::new(repo.local_branches());
-        let protected_branches = branches.protected(&protected);
+        let mut branches = git_stack::git::Branches::new([]);
+        let mut protected_branches = git_stack::git::Branches::new([]);
+        for branch in repo.local_branches() {
+            if protected.is_protected(&branch.name) {
+                log::trace!("Branch {} is protected", branch);
+                protected_branches.insert(branch.clone());
+            }
+            branches.insert(branch);
+        }
         let head_commit = repo.head_commit();
         let base = args
             .base

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -98,6 +98,10 @@ impl State {
             if protected.is_protected(&branch.name) {
                 log::trace!("Branch {} is protected", branch);
                 protected_branches.insert(branch.clone());
+                if let Some(remote) = repo.find_remote_branch(repo.pull_remote(), &branch.name) {
+                    protected_branches.insert(remote.clone());
+                    branches.insert(remote);
+                }
             }
             branches.insert(branch);
         }

--- a/src/git/branches.rs
+++ b/src/git/branches.rs
@@ -198,34 +198,6 @@ impl Branches {
             .collect();
         Self { branches }
     }
-
-    pub fn protected(&self, protected: &crate::git::ProtectedBranches) -> Self {
-        let branches: std::collections::BTreeMap<_, _> = self
-            .branches
-            .iter()
-            .filter_map(|(oid, branches)| {
-                let protected_branches: Vec<_> = branches
-                    .iter()
-                    .filter_map(|b| {
-                        // Protect branches, regardless of whether they are remote or not
-                        if protected.is_protected(&b.name) {
-                            log::trace!("Branch {} is protected", b);
-                            Some(b.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect();
-                if protected_branches.is_empty() {
-                    None
-                } else {
-                    Some((*oid, protected_branches))
-                }
-            })
-            .collect();
-
-        Self { branches }
-    }
 }
 
 impl IntoIterator for Branches {

--- a/tests/branches.rs
+++ b/tests/branches.rs
@@ -108,25 +108,6 @@ mod test_branches {
         // Shouldn't pick up feature1 (dependent) or master (branches off base)
         assert_eq!(names, ["base", "feature1"]);
     }
-
-    #[test]
-    fn test_protected() {
-        let mut repo = git_stack::git::InMemoryRepo::new();
-        let plan =
-            git_fixture::Dag::load(std::path::Path::new("tests/fixtures/branches.yml")).unwrap();
-        fixture::populate_repo(&mut repo, plan);
-
-        let protect = protect();
-        let branches = Branches::new(repo.local_branches());
-        let result = branches.protected(&protect);
-        let mut names: Vec<_> = result
-            .iter()
-            .flat_map(|(_, b)| b.iter().map(|b| b.to_string()))
-            .collect();
-        names.sort_unstable();
-
-        assert_eq!(names, ["master"]);
-    }
 }
 
 mod test_find_protected_base {
@@ -140,8 +121,10 @@ mod test_find_protected_base {
         fixture::populate_repo(&mut repo, plan);
 
         let protect = no_protect();
-        let branches = Branches::new(repo.local_branches());
-        let protected = branches.protected(&protect);
+        let protected = Branches::new(
+            repo.local_branches()
+                .filter(|b| protect.is_protected(&b.name)),
+        );
 
         let head_oid = repo.resolve("base").unwrap().id;
 
@@ -157,8 +140,10 @@ mod test_find_protected_base {
         fixture::populate_repo(&mut repo, plan);
 
         let protect = protect();
-        let branches = Branches::new(repo.local_branches());
-        let protected = branches.protected(&protect);
+        let protected = Branches::new(
+            repo.local_branches()
+                .filter(|b| protect.is_protected(&b.name)),
+        );
 
         let head_oid = repo.resolve("off_master").unwrap().id;
 
@@ -174,8 +159,10 @@ mod test_find_protected_base {
         fixture::populate_repo(&mut repo, plan);
 
         let protect = protect();
-        let branches = Branches::new(repo.local_branches());
-        let protected = branches.protected(&protect);
+        let protected = Branches::new(
+            repo.local_branches()
+                .filter(|b| protect.is_protected(&b.name)),
+        );
 
         let head_oid = repo.resolve("base").unwrap().id;
 


### PR DESCRIPTION
These will be hidden unless they diverge from the branches locally.

Cases where this would happen:
- You've done a manual fetch
- You've run `git branch-stash pop git-stack`
- You are developing on a protected branch (granted, we'll still mark it
  as protected)

This also leads towards https://github.com/gitext-rs/git-stack/issues/12