### PR TITLE
fix(git): Issues from tracking remotes

### DIFF
--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -466,7 +466,7 @@ fn plan_changes(state: &State, stack: &StackState) -> eyre::Result<git_stack::gi
             .as_ref()
             .map(|b| b.id)
             .unwrap_or(stack.onto.id);
-        let pull_start_id = stack.onto.id;
+        let pull_start_id = stack.base.id;
         let pull_start_id = state
             .repo
             .merge_base(pull_start_id, onto_id)
@@ -620,7 +620,7 @@ fn show(state: &State, colored_stdout: bool, colored_stderr: bool) -> eyre::Resu
                     .as_ref()
                     .map(|b| b.id)
                     .unwrap_or(stack.onto.id);
-                let pull_start_id = stack.onto.id;
+                let pull_start_id = stack.base.id;
                 let pull_start_id = state
                     .repo
                     .merge_base(pull_start_id, onto_id)

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -460,12 +460,7 @@ fn plan_changes(state: &State, stack: &StackState) -> eyre::Result<git_stack::gi
     let mut dropped_branches = Vec::new();
     if state.rebase {
         log::trace!("Rebasing onto {}", stack.onto);
-        let onto_id = stack
-            .onto
-            .branch
-            .as_ref()
-            .map(|b| b.id)
-            .unwrap_or(stack.onto.id);
+        let onto_id = stack.onto.id;
         let pull_start_id = stack.base.id;
         let pull_start_id = state
             .repo
@@ -614,12 +609,7 @@ fn show(state: &State, colored_stdout: bool, colored_stderr: bool) -> eyre::Resu
             // Show as-if we performed all mutations
             if state.rebase {
                 log::trace!("Rebasing onto {}", stack.onto);
-                let onto_id = stack
-                    .onto
-                    .branch
-                    .as_ref()
-                    .map(|b| b.id)
-                    .unwrap_or(stack.onto.id);
+                let onto_id = stack.onto.id;
                 let pull_start_id = stack.base.id;
                 let pull_start_id = state
                     .repo

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -97,10 +97,11 @@ impl State {
         for branch in repo.local_branches() {
             if protected.is_protected(&branch.name) {
                 log::trace!("Branch {} is protected", branch);
-                protected_branches.insert(branch.clone());
                 if let Some(remote) = repo.find_remote_branch(repo.pull_remote(), &branch.name) {
                     protected_branches.insert(remote.clone());
                     branches.insert(remote);
+                } else {
+                    protected_branches.insert(branch.clone());
                 }
             }
             branches.insert(branch);

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -14,7 +14,7 @@ pub fn protect_branches(
 
     let protected_oids: HashSet<_> = protected_branches
         .iter()
-        .flat_map(|(_, branches)| branches.iter().map(|b| b.pull_id.unwrap_or(b.id)))
+        .flat_map(|(_, branches)| branches.iter().map(|b| b.id))
         .collect();
 
     for protected_oid in protected_oids.into_iter().filter(|protected_oid| {


### PR DESCRIPTION
When tracking remotes for #12, we had a couple of regressions.

First, we might treat the local and remote branches as separate bases.  So instead we are switching to only protecting remote branches when a local branch is present.  This should implement the majority of #12's remaining work.

Second, we lost the tracking of the "pull range".  We
want to understand what commits were skipped when fast forwarding the
local base branch onto the remote.  We did this by having the local
branch be the base / protected.  We then compared the local `.id` to the
`.pull_id`.

By switching to protecting (and making the base) the remote branch,
`.id` and `.pull_id` became the same.  We could use `--base` and `--onto`
instead but they'll be the same in the default case.

So instead when we infer `--base` or `--onto`, we look for the local
(base) or remote (onto) equivalent of what we are inferring from.

Fixes #12 