### PR TITLE
fix: Handle repurcissions for remote support

### DIFF
--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -340,15 +340,15 @@ pub fn stack(
 
         for stack in state.stacks.iter() {
             if let Some(branch) = &stack.onto.branch {
-                if state.protected_branches.contains_oid(branch.id) {
-                    match git_fetch_upstream(&mut state.repo, branch.name.as_str()) {
+                if let Some(remote) = &branch.remote {
+                    match git_fetch_upstream(remote, branch.name.as_str()) {
                         Ok(_) => (),
                         Err(err) => {
                             log::warn!("Skipping pull of `{}`, {}", branch, err);
                         }
                     }
                 } else {
-                    log::warn!("Skipping pull of `{}`, not a protected branch", branch);
+                    log::warn!("Skipping pull of `{}` local branch", branch);
                 }
             }
         }
@@ -897,8 +897,7 @@ fn git_prune_development(
     Ok(())
 }
 
-fn git_fetch_upstream(repo: &mut git_stack::git::GitRepo, branch_name: &str) -> eyre::Result<()> {
-    let remote = repo.pull_remote();
+fn git_fetch_upstream(remote: &str, branch_name: &str) -> eyre::Result<()> {
     log::debug!("git fetch {} {}", remote, branch_name);
     // A little uncertain about some of the weirder authentication needs, just deferring to `git`
     // instead of using `libgit2`

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -375,21 +375,17 @@ pub fn rebase_pulled_branches(graph: &mut Graph, pull_start: git2::Oid, pull_end
         return;
     }
 
-    let mut branches = Default::default();
-    std::mem::swap(
-        &mut branches,
+    let branches = std::mem::take(
         &mut graph
             .get_mut(pull_start)
             .expect("all children exist")
             .branches,
     );
-    std::mem::swap(
-        &mut branches,
-        &mut graph
-            .get_mut(pull_end)
-            .expect("all children exist")
-            .branches,
-    );
+    graph
+        .get_mut(pull_end)
+        .expect("all children exist")
+        .branches
+        .extend(branches);
 }
 
 pub fn pushable(graph: &mut Graph) {

--- a/src/graph/ops.rs
+++ b/src/graph/ops.rs
@@ -381,11 +381,16 @@ pub fn rebase_pulled_branches(graph: &mut Graph, pull_start: git2::Oid, pull_end
             .expect("all children exist")
             .branches,
     );
+    let (start_branches, end_branches) = branches.into_iter().partition(|b| b.remote.is_some());
+    graph
+        .get_mut(pull_start)
+        .expect("all children exist")
+        .branches = start_branches;
     graph
         .get_mut(pull_end)
         .expect("all children exist")
         .branches
-        .extend(branches);
+        .extend(end_branches);
 }
 
 pub fn pushable(graph: &mut Graph) {


### PR DESCRIPTION
#211 and #212 built up support for #12 but there were some corner cases that weren't handled
- `main` was not being updated when pulling
- `main` showed as unprotected branch on a protected commit
- We weren't puling from the users selected remote
- We might push `main` which is good for a fork model but not for a central model

To address these, small tweaks were made that also streamline the code, making things more principled based which should hopefully make it clearer.

The downside is that we've gone back to `main` always being protected rather than allowing it to be unprotected and rebasing it.