### PR TITLE
fix(cli): Give space after each subtree

### DIFF
--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -1275,10 +1275,11 @@ impl<'r> Tree<'r> {
                 }
                 tree.push(stack_tree);
             } else {
-                if i != 0 && !stack.is_empty() {
-                    tree.push(termtree::Tree::root(joint).with_glyphs(SPACE_GLYPHS));
-                }
-                for child_tree in stack.into_iter() {
+                let stack_len = stack.len();
+                for (j, child_tree) in stack.into_iter().enumerate() {
+                    if i != 0 && j == 0 {
+                        tree.push(termtree::Tree::root(joint).with_glyphs(SPACE_GLYPHS));
+                    }
                     let child = RenderNode {
                         repo,
                         head_branch,
@@ -1287,17 +1288,23 @@ impl<'r> Tree<'r> {
                         palette,
                     };
                     tree.push(termtree::Tree::root(child).with_glyphs(GLYPHS));
-                    for child_stack in child_tree.stacks.into_iter() {
-                        let mut stack_tree = termtree::Tree::root(joint).with_glyphs(JOINT_GLYPHS);
-                        for child_tree in child_stack.into_iter() {
-                            stack_tree.push(child_tree.into_display(
-                                repo,
-                                head_branch,
-                                protected_branches,
-                                palette,
-                            ));
+                    if !child_tree.stacks.is_empty() {
+                        for child_stack in child_tree.stacks.into_iter() {
+                            let mut stack_tree =
+                                termtree::Tree::root(joint).with_glyphs(JOINT_GLYPHS);
+                            for child_tree in child_stack.into_iter() {
+                                stack_tree.push(child_tree.into_display(
+                                    repo,
+                                    head_branch,
+                                    protected_branches,
+                                    palette,
+                                ));
+                            }
+                            tree.push(stack_tree);
                         }
-                        tree.push(stack_tree);
+                        if j < stack_len {
+                            tree.push(termtree::Tree::root(joint).with_glyphs(SPACE_GLYPHS));
+                        }
                     }
                 }
             }


### PR DESCRIPTION
After #207, we ended up with
```
8dc84dc net: phy: broadcom: Enable 10BaseT DAC early wake
├─┐
│ ⌽ slow (ready) slow
│
⌽ master (no remote) Revert "gpio: Revert regression in sysfs-gpio (gpiolib.c)"
⌽ 551acdc Merge tag 'net-5.17-final' of git://git.kernel.org/pub/scm/linux/kernel/git/netdev/net
├─┐
│ ⌽ linux-5.17.y (no remote) Linux 5.17
│ ⌽ wmo/linux-5.17.y-backports (no remote) net: dsa: mv88e6xxx: Fill in STU support for all supported chips
│ ⌽ wmo/linux-5.17.y (pushed) net: dsa: Backport Marvell Peridot cmode fix from Netbox
⌽ net-bridge-host-l2-multicast (no remote) selftests: forwarding: verify flood of known mc on mcast_router port
```

We were giving space after the first gap but not subsequent.  We needed
something more like a `join` operation.  Now we do.