### PR TITLE
perf(cli): Split off highly divergent branches

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -129,6 +129,7 @@ Configuration is read from the following (in precedence order):
 | stack.protected-branch | \-       | multivar of globs          | Branch names that match these globs (`.gitignore` syntax) are considered protected branches |
 | stack.protect-commit-count | \-   | integer                    | Protect commits that are on a branch with `count`+ commits |
 | stack.protect-commit-age | \-     | time delta (e.g. 10days)   | Protect commits that older than the specified time |
+| stack.auto-base-commit-count | \-     | integer                | Split off branches that are more than `count` commits away from the implied base |
 | stack.stack            | --stack  | "current", "dependents", "descendants", "all" | Which development branch-stacks to operate on |
 | stack.push-remote      | \-       | string                     | Development remote for pushing local branches |
 | stack.pull-remote      | \-       | string                     | Upstream remote for pulling protected branches |

--- a/src/bin/git-stack/args.rs
+++ b/src/bin/git-stack/args.rs
@@ -89,6 +89,7 @@ impl Args {
             protected_branches: None,
             protect_commit_count: None,
             protect_commit_age: None,
+            auto_base_commit_count: None,
             stack: self.stack,
             push_remote: None,
             pull_remote: None,

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -808,8 +808,13 @@ fn resolve_implicit_base(
             AnnotatedOid::with_branch(branch.to_owned())
         }
         None => {
-            log::warn!("Could not find protected branch for {}", head_oid);
-            AnnotatedOid::new(head_oid)
+            let assumed_base_oid = git_stack::git::infer_base(repo, head_oid).unwrap_or(head_oid);
+            log::warn!(
+                "Could not find protected branch for {}, assuming {}",
+                head_oid,
+                assumed_base_oid
+            );
+            AnnotatedOid::new(assumed_base_oid)
         }
     };
     branch

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -135,8 +135,13 @@ impl State {
             (None, None, git_stack::config::Stack::All) => {
                 let mut stack_branches = std::collections::BTreeMap::new();
                 for (branch_id, branch) in branches.iter() {
-                    let base_branch =
-                        resolve_implicit_base(&repo, branch_id, &branches, &protected_branches);
+                    let base_branch = resolve_implicit_base(
+                        &repo,
+                        branch_id,
+                        &branches,
+                        &protected_branches,
+                        repo_config.auto_base_commit_count(),
+                    );
                     stack_branches
                         .entry(base_branch)
                         .or_insert_with(git_stack::git::Branches::default)
@@ -163,6 +168,7 @@ impl State {
                             head_commit.id,
                             &branches,
                             &protected_branches,
+                            repo_config.auto_base_commit_count(),
                         );
                         // HACK: Since `base` might have come back with a remote branch, treat it as an
                         // "onto" to find the local version.
@@ -175,6 +181,7 @@ impl State {
                             head_commit.id,
                             &branches,
                             &protected_branches,
+                            repo_config.auto_base_commit_count(),
                         );
                         let base = resolve_base_from_onto(&repo, &onto);
                         (base, onto)
@@ -787,9 +794,45 @@ fn resolve_implicit_base(
     head_oid: git2::Oid,
     branches: &git_stack::git::Branches,
     protected_branches: &git_stack::git::Branches,
+    auto_base_commit_count: Option<usize>,
 ) -> AnnotatedOid {
-    let branch = match git_stack::git::find_protected_base(repo, protected_branches, head_oid) {
+    match git_stack::git::find_protected_base(repo, protected_branches, head_oid) {
         Some(branch) => {
+            let merge_base_id = repo
+                .merge_base(branch.id, head_oid)
+                .expect("to be a base, there must be a merge base");
+            if let Some(max_commit_count) = auto_base_commit_count {
+                let ahead_count = repo
+                    .commit_count(merge_base_id, head_oid)
+                    .expect("merge_base should ensure a count exists ");
+                let behind_count = repo
+                    .commit_count(merge_base_id, branch.id)
+                    .expect("merge_base should ensure a count exists ");
+                if max_commit_count <= ahead_count + behind_count {
+                    let assumed_base_oid =
+                        git_stack::git::infer_base(repo, head_oid).unwrap_or(head_oid);
+                    log::warn!(
+                        "{} is {} ahead and {} behind {}, using {} as --base instead",
+                        branches
+                            .get(head_oid)
+                            .map(|b| b[0].to_string())
+                            .or_else(|| {
+                                repo.find_commit(head_oid)?
+                                    .summary
+                                    .to_str()
+                                    .ok()
+                                    .map(ToOwned::to_owned)
+                            })
+                            .unwrap_or_else(|| "target".to_owned()),
+                        ahead_count,
+                        behind_count,
+                        branch,
+                        assumed_base_oid
+                    );
+                    return AnnotatedOid::new(assumed_base_oid);
+                }
+            }
+
             log::debug!(
                 "Chose branch {} as the base for {}",
                 branch,
@@ -816,8 +859,7 @@ fn resolve_implicit_base(
             );
             AnnotatedOid::new(assumed_base_oid)
         }
-    };
-    branch
+    }
 }
 
 fn resolve_base_from_onto(repo: &git_stack::git::GitRepo, onto: &AnnotatedOid) -> AnnotatedOid {

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -199,7 +199,11 @@ impl GitRepo {
             .bases
             .borrow_mut()
             .entry((smaller, larger))
-            .or_insert_with(|| self.repo.merge_base(smaller, larger).ok())
+            .or_insert_with(|| self.merge_base_raw(smaller, larger))
+    }
+
+    fn merge_base_raw(&self, one: git2::Oid, two: git2::Oid) -> Option<git2::Oid> {
+        self.repo.merge_base(one, two).ok()
     }
 
     pub fn find_commit(&self, id: git2::Oid) -> Option<std::rc::Rc<Commit>> {

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -194,11 +194,12 @@ impl GitRepo {
             return Some(one);
         }
 
+        let (smaller, larger) = if one < two { (one, two) } else { (two, one) };
         *self
             .bases
             .borrow_mut()
-            .entry((one, two))
-            .or_insert_with(|| self.repo.merge_base(one, two).ok())
+            .entry((smaller, larger))
+            .or_insert_with(|| self.repo.merge_base(smaller, larger).ok())
     }
 
     pub fn find_commit(&self, id: git2::Oid) -> Option<std::rc::Rc<Commit>> {

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -124,6 +124,7 @@ pub struct GitRepo {
     commits: std::cell::RefCell<std::collections::HashMap<git2::Oid, std::rc::Rc<Commit>>>,
     interned_strings: std::cell::RefCell<std::collections::HashSet<std::rc::Rc<str>>>,
     bases: std::cell::RefCell<std::collections::HashMap<(git2::Oid, git2::Oid), Option<git2::Oid>>>,
+    counts: std::cell::RefCell<std::collections::HashMap<(git2::Oid, git2::Oid), Option<usize>>>,
 }
 
 impl GitRepo {
@@ -135,6 +136,7 @@ impl GitRepo {
             commits: Default::default(),
             interned_strings: Default::default(),
             bases: Default::default(),
+            counts: Default::default(),
         }
     }
 
@@ -289,6 +291,14 @@ impl GitRepo {
             return Some(0);
         }
 
+        *self
+            .counts
+            .borrow_mut()
+            .entry((base_id, head_id))
+            .or_insert_with(|| self.commit_count_raw(base_id, head_id))
+    }
+
+    fn commit_count_raw(&self, base_id: git2::Oid, head_id: git2::Oid) -> Option<usize> {
         let merge_base_id = self.merge_base(base_id, head_id)?;
         if merge_base_id != base_id {
             return None;


### PR DESCRIPTION
In https://github.com/gitext-rs/git-stack/discussions/216, a user is backporting changes on Linux and hadn't marked
protected branches which would serve as bases, causing git-stack to
topologically sort commits that are very distant from each other,
causing a simple showing of the commit graph to take 20-30s.

This change infers that these branches are do not belong to their base
and split them off.  Now showing the commit graph takes about 6s as it
tries each base.