### PR TITLE
fix: Always protect foreign branches

### DIFF
--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -466,7 +466,7 @@ fn plan_changes(state: &State, stack: &StackState) -> eyre::Result<git_stack::gi
         &[state.head_commit.id],
     );
     if let Some(user) = state.repo.user() {
-        git_stack::graph::protect_foreign_branches(&mut graph, &user, &[state.head_commit.id]);
+        git_stack::graph::protect_foreign_branches(&mut graph, &user, &[]);
     }
 
     let mut dropped_branches = Vec::new();
@@ -535,7 +535,7 @@ fn push(state: &mut State) -> eyre::Result<()> {
         &[state.head_commit.id],
     );
     if let Some(user) = state.repo.user() {
-        git_stack::graph::protect_foreign_branches(&mut graph, &user, &[state.head_commit.id]);
+        git_stack::graph::protect_foreign_branches(&mut graph, &user, &[]);
     }
 
     git_stack::graph::pushable(&mut graph);
@@ -612,6 +612,7 @@ fn show(state: &State, colored_stdout: bool, colored_stderr: bool) -> eyre::Resu
                     .into_iter()
                     .map(|b| format!("{}", palette_stderr.warn.paint(b))),
                 );
+                git_stack::graph::protect_foreign_branches(&mut graph, &user, &[]);
             }
         }
 


### PR DESCRIPTION
Before, we auto-protected and trimmed all foreign or old branches,
unless they are the HEAD.
Context-specific behavior though can be confusing (especially when
people are frequently pulling other people's branches for read-only
purposes like reviewing).

Now, we unconditionally protect all foreign branches.
- Old branches are a bit of a special case; they should be fine to
  update if they are HEAD
- We still special case for trimming to provide context for the user.

Next steps
- Improve the workflow for taking over someone else's branch.  Right
  now, it requires making a change outside of `git stack`
- Show protected commits on a foreign branch

Fixes #232