### PR TITLE
feat(run): Fail fast support

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -276,7 +276,7 @@ impl AncestorsCursor {
 }
 
 impl AncestorsCursor {
-    fn next(&mut self, graph: &Graph) -> Option<git2::Oid> {
+    pub fn next(&mut self, graph: &Graph) -> Option<git2::Oid> {
         if let Some(prior) = self.prior {
             if self.primary_parents {
                 // Single path, no chance for duplicating paths
@@ -339,7 +339,7 @@ impl DescendantsCursor {
 }
 
 impl DescendantsCursor {
-    fn next(&mut self, graph: &Graph) -> Option<git2::Oid> {
+    pub fn next(&mut self, graph: &Graph) -> Option<git2::Oid> {
         if let Some(prior) = self.prior {
             self.node_queue.extend(graph.primary_children_of(prior));
         }


### PR DESCRIPTION
If a command failed on a commit, we won't run the command on the descendant commits as they are likely to fail as well and someone is likely wanting to fix the first failure.

The default can be configured by changing the alias to include `--no-ff`.  A user can then override this with the hidden `--ff`.

Fixes #262