### PR TITLE
fix(amend): Don't drop commits after target

### DIFF
--- a/src/bin/git-stack/amend.rs
+++ b/src/bin/git-stack/amend.rs
@@ -144,7 +144,9 @@ impl AmendArgs {
         )
         .with_code(proc_exit::Code::FAILURE)?;
         if let Some(fixup_id) = fixup_id {
-            graph.insert(git_stack::graph::Node::new(fixup_id), head_id);
+            if let Some(parent_id) = repo.parent_ids(fixup_id).expect("commit exists").first() {
+                graph.insert(git_stack::graph::Node::new(fixup_id), *parent_id);
+            }
             graph.commit_set(fixup_id, git_stack::graph::Fixup);
         }
         graph

--- a/tests/testsuite/amend.rs
+++ b/tests/testsuite/amend.rs
@@ -237,6 +237,7 @@ fn reword_rebases() {
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("git-stack"))
         .arg("amend")
         .arg("--message=new B")
+        .arg("target")
         .current_dir(root_path)
         .assert()
         .success()
@@ -247,7 +248,7 @@ fn reword_rebases() {
         .stderr_matches(
             "\
 Saved working directory and index state WIP on local (amend): [..]
-Amended to [..]: C
+Amended to [..]: B
 Dropped refs/stash [..]
 note: to undo, run `git branch-stash pop git-stack`
 ",
@@ -255,6 +256,10 @@ note: to undo, run `git branch-stash pop git-stack`
 
     let new_head_id = repo.head_commit().id;
     assert_ne!(old_head_id, new_head_id);
+
+    let local_branch = repo.find_local_branch("local").unwrap();
+    let local_commit = repo.find_commit(local_branch.id).unwrap();
+    snapbox::assert_eq(local_commit.summary.to_str_lossy().into_owned(), "C");
 
     snapbox::assert_eq(std::fs::read(root_path.join("a")).unwrap(), "unstaged a");
 
@@ -479,6 +484,10 @@ note: to undo, run `git branch-stash pop git-stack`
     let new_head_id = repo.head_commit().id;
     assert_ne!(old_head_id, new_head_id);
 
+    let local_branch = repo.find_local_branch("local").unwrap();
+    let local_commit = repo.find_commit(local_branch.id).unwrap();
+    snapbox::assert_eq(local_commit.summary.to_str_lossy().into_owned(), "C");
+
     snapbox::assert_eq(std::fs::read(root_path.join("a")).unwrap(), "unstaged a");
 
     root.close().unwrap();
@@ -636,6 +645,10 @@ note: to undo, run `git branch-stash pop git-stack`
     let new_head_id = repo.head_commit().id;
     assert_ne!(old_head_id, new_head_id);
 
+    let local_branch = repo.find_local_branch("local").unwrap();
+    let local_commit = repo.find_commit(local_branch.id).unwrap();
+    snapbox::assert_eq(local_commit.summary.to_str_lossy().into_owned(), "C");
+
     snapbox::assert_eq(std::fs::read(root_path.join("a")).unwrap(), "unstaged a");
 
     root.close().unwrap();
@@ -717,9 +730,13 @@ note: to undo, run `git branch-stash pop git-stack`
     let new_head_id = repo.head_commit().id;
     assert_ne!(old_head_id, new_head_id);
 
-    snapbox::assert_eq(std::fs::read(root_path.join("a")).unwrap(), "unstaged a");
-
     snapbox::assert_eq(repo.head_commit().summary.to_str().unwrap(), "fixup! B");
+
+    let local_branch = repo.find_local_branch("local").unwrap();
+    let local_commit = repo.find_commit(local_branch.id).unwrap();
+    snapbox::assert_eq(local_commit.summary.to_str_lossy().into_owned(), "fixup! B");
+
+    snapbox::assert_eq(std::fs::read(root_path.join("a")).unwrap(), "unstaged a");
 
     root.close().unwrap();
 }

--- a/tests/testsuite/reword.rs
+++ b/tests/testsuite/reword.rs
@@ -258,6 +258,10 @@ note: to undo, run `git branch-stash pop git-stack`
     let commit = repo.find_commit(branch.id).unwrap();
     snapbox::assert_eq(commit.summary.to_str().unwrap(), "new B");
 
+    let local_branch = repo.find_local_branch("local").unwrap();
+    let local_commit = repo.find_commit(local_branch.id).unwrap();
+    snapbox::assert_eq(local_commit.summary.to_str_lossy().into_owned(), "C");
+
     let new_head_id = repo.head_commit().id;
     assert_ne!(old_head_id, new_head_id);
 


### PR DESCRIPTION
When amending a non-HEAD commit, we dropped all of the commits after it as we accidentally moved the branch to point to the fixup target.