### PR TITLE
fix: Report in-progress error earlier 

### DIFF
--- a/src/bin/git-stack/amend.rs
+++ b/src/bin/git-stack/amend.rs
@@ -115,6 +115,19 @@ impl AmendArgs {
         git_stack::graph::mark_fixup(&mut graph, &repo);
         git_stack::graph::mark_wip(&mut graph, &repo);
 
+        if repo.raw().state() != git2::RepositoryState::Clean {
+            let message = format!("cannot walk commits, {:?} in progress", repo.raw().state());
+            if self.dry_run {
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "{}: {}",
+                    stderr_palette.error.paint("error"),
+                    message
+                );
+            } else {
+                return Err(proc_exit::sysexits::USAGE_ERR.with_message(message));
+            }
+        }
         let action = graph
             .commit_get::<git_stack::graph::Action>(head_id)
             .copied()

--- a/src/bin/git-stack/next.rs
+++ b/src/bin/git-stack/next.rs
@@ -60,6 +60,20 @@ impl NextArgs {
         let branches = git_stack::graph::BranchSet::from_repo(&repo, &protected)
             .with_code(proc_exit::Code::FAILURE)?;
 
+        if repo.raw().state() != git2::RepositoryState::Clean {
+            let message = format!("cannot move to next, {:?} in progress", repo.raw().state());
+            if self.dry_run {
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "{}: {}",
+                    stderr_palette.error.paint("error"),
+                    message
+                );
+            } else {
+                return Err(proc_exit::sysexits::USAGE_ERR.with_message(message));
+            }
+        }
+
         if self.stash && !self.dry_run {
             git_stack::git::stash_push(&mut repo, "branch-stash");
         }

--- a/src/bin/git-stack/reword.rs
+++ b/src/bin/git-stack/reword.rs
@@ -1,3 +1,5 @@
+use std::io::Write;
+
 use itertools::Itertools;
 use proc_exit::prelude::*;
 
@@ -93,6 +95,19 @@ impl RewordArgs {
         git_stack::graph::mark_fixup(&mut graph, &repo);
         git_stack::graph::mark_wip(&mut graph, &repo);
 
+        if repo.raw().state() != git2::RepositoryState::Clean {
+            let message = format!("cannot walk commits, {:?} in progress", repo.raw().state());
+            if self.dry_run {
+                let _ = writeln!(
+                    std::io::stderr(),
+                    "{}: {}",
+                    stderr_palette.error.paint("error"),
+                    message
+                );
+            } else {
+                return Err(proc_exit::sysexits::USAGE_ERR.with_message(message));
+            }
+        }
         let action = graph
             .commit_get::<git_stack::graph::Action>(head_id)
             .copied()

--- a/src/git/repo.rs
+++ b/src/git/repo.rs
@@ -178,11 +178,6 @@ impl GitRepo {
     }
 
     pub fn is_dirty(&self) -> bool {
-        if self.repo.state() != git2::RepositoryState::Clean {
-            log::trace!("Repository status is unclean: {:?}", self.repo.state());
-            return true;
-        }
-
         let status = self
             .repo
             .statuses(Some(git2::StatusOptions::new().include_ignored(false)))

--- a/tests/testsuite/reword.rs
+++ b/tests/testsuite/reword.rs
@@ -237,6 +237,8 @@ fn reword_branch() {
 
     let old_head_id = repo.head_commit().id;
 
+    std::fs::write(root_path.join("a"), "unstaged a").unwrap();
+
     snapbox::cmd::Command::new(snapbox::cmd::cargo_bin!("git-stack"))
         .arg("reword")
         .arg("--message=new B")
@@ -248,8 +250,10 @@ fn reword_branch() {
             "\
 ",
         )
-        .stderr_eq(
+        .stderr_matches(
             "\
+Saved working directory and index state WIP on local (reword): [..]
+Dropped refs/stash [..]
 note: to undo, run `git branch-stash pop git-stack`
 ",
         );
@@ -264,6 +268,8 @@ note: to undo, run `git branch-stash pop git-stack`
 
     let new_head_id = repo.head_commit().id;
     assert_ne!(old_head_id, new_head_id);
+
+    snapbox::assert_eq(std::fs::read(root_path.join("a")).unwrap(), "unstaged a");
 
     root.close().unwrap();
 }


### PR DESCRIPTION
- This clarifies the error message
- This reports it before performing side effects
- We report it for reword which we weren't doing before
- This fixes `is_dirty` checks for doing things like stashing