### PR TITLE
fix(stack): Show correct branch position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -525,7 +525,7 @@ With `git stack alias` for creating alias for these
 - Load config when in a worktree
 - Restore correct HEAD when multiple branches on the same commit
 
-### Breaking Chanages
+### Breaking Changes
 
 - Renamed `--format` options:
   - `brief` -> `branches`

--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -1612,7 +1612,6 @@ fn format_branch_status<'d>(
         if node.branches.is_empty() {
             String::new()
         } else {
-            let branch = &node.branches[0];
             match commit_relation(repo, branch.id, branch.push_id) {
                 Some((0, 0)) => {
                     format!(" {}", palette.good("(pushed)"))


### PR DESCRIPTION
For some reason, we ignored the branch we were supposed to show it for and only showed it for the first.