### PR TITLE
fix: add humantime feature to env_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -303,6 +303,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
+ "humantime",
  "log",
  "termcolor",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ git-config-env = "0.1"
 clap = { version = "4.3.0", features = ["derive"] }
 clap-verbosity-flag = "2.0.1"
 log = "0.4"
-env_logger = { version = "0.10", default-features = false, features = ["color"] }
+env_logger = { version = "0.10", default-features = false, features = ["humantime", "color"] }
 colorchoice-clap = "1.0.0"
 anstyle = "1.0.0"
 anstream = "0.3.2"


### PR DESCRIPTION
Without this, the `builder.format_timestamp_millis()` statement in `logger.rs` has no effect