### PR TITLE
Use unicode box drawing glyphs for the tree view

### DIFF
--- a/src/bin/git-stack/stack.rs
+++ b/src/bin/git-stack/stack.rs
@@ -1453,8 +1453,8 @@ struct RenderNode<'r> {
 }
 
 const GLYPHS: termtree::GlyphPalette = termtree::GlyphPalette {
-    middle_item: "⌽",
-    last_item: "⌽",
+    middle_item: "○",
+    last_item: "●",
     item_indent: " ",
     skip_indent: " ",
     ..termtree::GlyphPalette::new()
@@ -1469,7 +1469,7 @@ const SPACE_GLYPHS: termtree::GlyphPalette = termtree::GlyphPalette {
 };
 
 const JOINT_GLYPHS: termtree::GlyphPalette = termtree::GlyphPalette {
-    item_indent: "─┐",
+    item_indent: "─╮",
     ..termtree::GlyphPalette::new()
 };
 


### PR DESCRIPTION
(Somewhat subjective)

The character `⌽` is not really a unicode box drawing character and doesn't quite line up with the verticals. Use ○ / ● instead which are centered on both axes

The `╮` symbol complements the roundness of the circles.

Inspired by `tig` graph rendering.