### PR TITLE
fix(graph): Ensure local master moves to upstream

### DIFF
--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -162,12 +162,6 @@ impl Graph {
             .neighbors_directed(root_id, petgraph::Direction::Incoming)
     }
 
-    pub fn primary_children_of(&self, root_id: git2::Oid) -> impl Iterator<Item = git2::Oid> + '_ {
-        self.graph
-            .edges_directed(root_id, petgraph::Direction::Incoming)
-            .filter_map(|(child, _parent, weight)| (*weight == 0).then_some(child))
-    }
-
     pub fn ancestors_of(&self, root_id: git2::Oid) -> AncestorsIter<'_> {
         let cursor = AncestorsCursor::new(self, root_id);
         AncestorsIter {
@@ -343,7 +337,7 @@ impl DescendantsCursor {
 impl DescendantsCursor {
     pub fn next(&mut self, graph: &Graph) -> Option<git2::Oid> {
         if let Some(prior) = self.prior {
-            self.node_queue.extend(graph.primary_children_of(prior));
+            self.node_queue.extend(graph.children_of(prior));
         }
         let next = self.node_queue.pop_front()?;
         self.prior = Some(next);


### PR DESCRIPTION
Repeatedly, the local master doesn't get moved.  This seems to fix it.
- We weren't checking for branches on the starting commit and sometimes we start on the new master
- When on a branch commit, we weren't correctly walking children because we were talking about "primary" when there isn't always a primary commit

I'm a bit unsure on that last one.  Hope this doesn't break more